### PR TITLE
Add readthedocs configuration to deploy docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# RTD API version
+version: 2
+
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: >-
+      3.11
+  commands:
+    - mkdir -p $READTHEDOCS_OUTPUT/html/
+    - cp -r docs/* $READTHEDOCS_OUTPUT/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,5 +10,5 @@ build:
     python: >-
       3.11
   commands:
-    - mkdir -p $READTHEDOCS_OUTPUT/html/
-    - cp -r docs/* $READTHEDOCS_OUTPUT/html/
+  - mkdir -pv "${READTHEDOCS_OUTPUT}"/html/
+  - cp -rv docs/* "${READTHEDOCS_OUTPUT}"/html/


### PR DESCRIPTION
Relates to https://github.com/ansible/ansible-documentation/pull/1353

A github workflow in the `ansible/ansible-documentation` repository pushes HTML and other assets generated from the package docs build into this repository. The files in this PR are used to then deploy the docs build to a Read The Docs project so that the Ansible community package docs will be available from https://ansible.readthedocs.io/projects/ansible/
