### PR TITLE
Remove unused Python version from RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,6 @@ version: 2
 
 build:
   os: ubuntu-lts-latest
-  tools:
-    python: >-
-      3.11
   commands:
   - mkdir -pv "${READTHEDOCS_OUTPUT}"/html/
   - cp -rv docs/* "${READTHEDOCS_OUTPUT}"/html/


### PR DESCRIPTION
There is no need to specify a Python version in .readthedocs.yaml Building on Read the Docs involves using shell commands only.

Tested on my fork. Here's the relevant portion of the logs:

```
[rtd-command-info] start-time: 2025-11-12T13:02:34.309164Z, end-time: 2025-11-12T13:02:34.353471Z, duration: 0, exit-code: 0
cat .readthedocs.yaml
# Read the Docs configuration file
# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details

# RTD API version
version: 2

build:
  os: ubuntu-lts-latest
  commands:
  - mkdir -pv "${READTHEDOCS_OUTPUT}"/html/
  - cp -rv docs/* "${READTHEDOCS_OUTPUT}"/html/

[rtd-command-info] start-time: 2025-11-12T13:02:35.125431Z, end-time: 2025-11-12T13:02:35.166649Z, duration: 0, exit-code: 0
mkdir -pv "${READTHEDOCS_OUTPUT}"/html/
mkdir: created directory '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs'
mkdir: created directory '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs//html/'

[rtd-command-info] start-time: 2025-11-12T13:02:35.211481Z, end-time: 2025-11-12T13:02:36.543997Z, duration: 1, exit-code: 0
cp -rv docs/* "${READTHEDOCS_OUTPUT}"/html/
'docs/404.html' -> '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs//html/404.html'
'docs/YAMLSyntax.html' -> '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs//html/YAMLSyntax.html'
'docs/_downloads' -> '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs//html/_downloads'
'docs/_downloads/47cc11a5d29fe635cb56cb6e1cd74e0f' -> '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs//html/_downloads/47cc11a5d29fe635cb56cb6e1cd74e0f'
'docs/_downloads/47cc11a5d29fe635cb56cb6e1cd74e0f/first_playbook_ext.yml' -> '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs//html/_downloads/47cc11a5d29fe635cb56cb6e1cd74e0f/first_playbook_ext.yml'
'docs/_downloads/588d4b6e9316c8eb903fbe2485b14d64' -> '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs//html/_downloads/588d4b6e9316c8eb903fbe2485b14d64'
'docs/_downloads/588d4b6e9316c8eb903fbe2485b14d64/first_playbook.yml' -> '/home/docs/checkouts/readthedocs.org/user_builds/oranod-package-doc-builds/checkouts/latest/_readthedocs//html/_downloads/588d4b6e9316c8eb903fbe2485b14d64/first_playbook.yml'

...
```